### PR TITLE
feat: allow to configure HPA and VPA for any service

### DIFF
--- a/tutorpod_autoscaling/patches/k8s-override
+++ b/tutorpod_autoscaling/patches/k8s-override
@@ -1,91 +1,25 @@
-{%- if POD_AUTOSCALING_LMS_HPA %}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lms
-spec:
-  template:
-    spec:
-      containers:
-        - name: lms
-          resources:
-            requests:
-              memory: {{ POD_AUTOSCALING_LMS_MEMORY_REQUEST }}
-            {%- if POD_AUTOSCALING_LMS_CPU_REQUEST > 0 %}
-              cpu: {{ POD_AUTOSCALING_LMS_CPU_REQUEST }}
-            {%- endif %}
-            limits:
-              memory: {{ POD_AUTOSCALING_LMS_MEMORY_LIMIT }}
-              {%- if POD_AUTOSCALING_LMS_CPU_LIMIT > 0 %}
-              cpu: {{ POD_AUTOSCALING_LMS_CPU_LIMIT }}
-              {%- endif %}
-{%- endif %}
+{% for service_name, config in POD_AUTOSCALING_SERVICES.items() %}
 ---
-{%- if POD_AUTOSCALING_LMS_WORKER_HPA %}
+{%- if config.hpa.enabled %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: lms-worker
+  name: {{service_name}}
 spec:
   template:
     spec:
       containers:
-        - name: lms-worker
+        - name: {{service_name}}
           resources:
             requests:
-              memory: {{ POD_AUTOSCALING_LMS_WORKER_MEMORY_REQUEST }}
-            {%- if POD_AUTOSCALING_LMS_WORKER_CPU_REQUEST > 0 %}
-              cpu: {{ POD_AUTOSCALING_LMS_WORKER_CPU_REQUEST }}
+              memory: {{ config.hpa.memory_request }}
+            {%- if config.hpa.cpu_request | float > 0 %}
+              cpu: {{ config.hpa.cpu_request }}
             {%- endif %}
             limits:
-              memory: {{ POD_AUTOSCALING_LMS_WORKER_MEMORY_LIMIT }}
-              {%- if POD_AUTOSCALING_LMS_WORKER_CPU_LIMIT > 0 %}
-              cpu: {{ POD_AUTOSCALING_LMS_WORKER_CPU_LIMIT }}
+              memory: {{ config.hpa.memory_limit }}
+              {%- if config.hpa.cpu_limit | float > 0 %}
+              cpu: {{ config.hpa.cpu_limit }}
               {%- endif %}
 {%- endif %}
----
-{%- if POD_AUTOSCALING_CMS_HPA %}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cms
-spec:
-  template:
-    spec:
-      containers:
-        - name: cms
-          resources:
-            requests:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_REQUEST }}
-            {%- if POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST }}
-            {%- endif %}
-            limits:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_LIMIT }}
-              {%- if POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT }}
-              {%- endif %}
-{%- endif %}
----
-{%- if POD_AUTOSCALING_CMS_WORKER_HPA %}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cms-worker
-spec:
-  template:
-    spec:
-      containers:
-        - name: cms-worker
-          resources:
-            requests:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_REQUEST }}
-            {%- if POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST }}
-            {%- endif %}
-            limits:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_LIMIT }}
-              {%- if POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT }}
-              {%- endif %}
-{%- endif %}
+{% endfor %}

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -82,6 +82,73 @@ config = {
         "LMS_WORKER_VPA": False,
         "CMS_VPA": False,
         "CMS_WORKER_VPA": False,
+        # Services to autoscale
+        "SERVICES": {
+            "lms": {
+                "hpa": {
+                    "enabled": "{{ POD_AUTOSCALING_LMS_HPA }}",
+                    "avg_cpu": "{{ POD_AUTOSCALING_LMS_AVG_CPU }}",
+                    "avg_memory": "{{ POD_AUTOSCALING_LMS_AVG_MEMORY }}",
+                    "cpu_limit": "{{ POD_AUTOSCALING_LMS_CPU_LIMIT }}",
+                    "cpu_request": "{{ POD_AUTOSCALING_LMS_CPU_REQUEST }}",
+                    "max_replicas": "{{ POD_AUTOSCALING_LMS_MAX_REPLICAS }}",
+                    "memory_limit": "{{ POD_AUTOSCALING_LMS_MEMORY_LIMIT }}",
+                    "memory_request": "{{ POD_AUTOSCALING_LMS_MEMORY_REQUEST }}",
+                    "min_replicas": "{{ POD_AUTOSCALING_LMS_MIN_REPLICAS }}",
+                },
+                "vpa": {
+                    "enabled": "{{ POD_AUTOSCALING_LMS_VPA }}",
+                },
+            },
+            "lms-worker": {
+                "hpa": {
+                    "enabled": "{{ POD_AUTOSCALING_LMS_WORKER_HPA }}",
+                    "avg_cpu": "{{ POD_AUTOSCALING_LMS_WORKER_AVG_CPU }}",
+                    "avg_memory": "{{ POD_AUTOSCALING_LMS_WORKER_AVG_MEMORY }}",
+                    "cpu_limit": "{{ POD_AUTOSCALING_LMS_WORKER_CPU_LIMIT }}",
+                    "cpu_request": "{{ POD_AUTOSCALING_LMS_WORKER_CPU_REQUEST }}",
+                    "max_replicas": "{{ POD_AUTOSCALING_LMS_WORKER_MAX_REPLICAS }}",
+                    "memory_limit": "{{ POD_AUTOSCALING_LMS_WORKER_MEMORY_LIMIT }}",
+                    "memory_request": "{{ POD_AUTOSCALING_LMS_WORKER_MEMORY_REQUEST }}",
+                    "min_replicas": "{{ POD_AUTOSCALING_LMS_WORKER_MIN_REPLICAS }}",
+                },
+                "vpa": {
+                    "enabled": "{{ POD_AUTOSCALING_LMS_WORKER_VPA }}",
+                },
+            },
+            "cms": {
+                "hpa": {
+                    "enabled": "{{ POD_AUTOSCALING_CMS_HPA }}",
+                    "avg_cpu": "{{ POD_AUTOSCALING_CMS_AVG_CPU }}",
+                    "avg_memory": "{{ POD_AUTOSCALING_CMS_AVG_MEMORY }}",
+                    "cpu_limit": "{{ POD_AUTOSCALING_CMS_CPU_LIMIT }}",
+                    "cpu_request": "{{ POD_AUTOSCALING_CMS_CPU_REQUEST }}",
+                    "max_replicas": "{{ POD_AUTOSCALING_CMS_MAX_REPLICAS }}",
+                    "memory_limit": "{{ POD_AUTOSCALING_CMS_MEMORY_LIMIT }}",
+                    "memory_request": "{{ POD_AUTOSCALING_CMS_MEMORY_REQUEST }}",
+                    "min_replicas": "{{ POD_AUTOSCALING_CMS_MIN_REPLICAS }}",
+                },
+                "vpa": {
+                    "enabled": "{{ POD_AUTOSCALING_CMS_VPA }}",
+                },
+            },
+            "cms-worker": {
+                "hpa": {
+                    "enabled": "{{ POD_AUTOSCALING_CMS_WORKER_HPA }}",
+                    "avg_cpu": "{{ POD_AUTOSCALING_CMS_WORKER_AVG_CPU }}",
+                    "avg_memory": "{{ POD_AUTOSCALING_CMS_WORKER_AVG_MEMORY }}",
+                    "cpu_limit": "{{ POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT }}",
+                    "cpu_request": "{{ POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST }}",
+                    "max_replicas": "{{ POD_AUTOSCALING_CMS_WORKER_MAX_REPLICAS }}",
+                    "memory_limit": "{{ POD_AUTOSCALING_CMS_WORKER_MEMORY_LIMIT }}",
+                    "memory_request": "{{ POD_AUTOSCALING_CMS_WORKER_MEMORY_REQUEST }}",
+                    "min_replicas": "{{ POD_AUTOSCALING_CMS_WORKER_MIN_REPLICAS }}",
+                },
+                "vpa": {
+                    "enabled": "{{ POD_AUTOSCALING_CMS_WORKER_VPA }}",
+                },
+            },
+        }
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.

--- a/tutorpod_autoscaling/templates/pod-autoscaling/k8s/hpa.yml
+++ b/tutorpod_autoscaling/templates/pod-autoscaling/k8s/hpa.yml
@@ -1,132 +1,37 @@
-{%- if POD_AUTOSCALING_LMS_HPA %}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: lms-hpa
-  labels:
-    app.kubernetes.io/name: lms-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: lms
-  minReplicas: {{ POD_AUTOSCALING_LMS_MIN_REPLICAS }}
-  maxReplicas: {{ POD_AUTOSCALING_LMS_MAX_REPLICAS }}
-  metrics:
-  {%- if POD_AUTOSCALING_LMS_AVG_CPU > 0 %}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ POD_AUTOSCALING_LMS_AVG_CPU }}
-  {%- endif %}
-  {%- if POD_AUTOSCALING_LMS_AVG_MEMORY|length %}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: AverageValue
-        averageValue: {{ POD_AUTOSCALING_LMS_AVG_MEMORY }}
-  {%- endif %}
-{%- endif %}
-{%- if POD_AUTOSCALING_LMS_WORKER_HPA %}
+{% for service_name, config in POD_AUTOSCALING_SERVICES.items() %}
+{%- if config.hpa.enabled %}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: lms-worker-hpa
+  name: {{ service_name }}-hpa
   labels:
-    app.kubernetes.io/name: lms-worker-hpa
+    app.kubernetes.io/name: {{ service_name }}-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: lms-worker
-  minReplicas: {{ POD_AUTOSCALING_LMS_WORKER_MIN_REPLICAS }}
-  maxReplicas: {{ POD_AUTOSCALING_LMS_WORKER_MAX_REPLICAS }}
+    name: {{ service_name }}
+  minReplicas: {{ config.hpa.min_replicas }}
+  maxReplicas: {{ config.hpa.max_replicas }}
   metrics:
-  {%- if POD_AUTOSCALING_LMS_WORKER_AVG_CPU > 0 %}
+  {%- if config.hpa.avg_cpu | float > 0 %}
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ POD_AUTOSCALING_LMS_WORKER_AVG_CPU }}
+        averageUtilization: {{ config.hpa.avg_cpu | float }}
   {%- endif %}
-  {%- if POD_AUTOSCALING_LMS_WORKER_AVG_MEMORY|length %}
+  {%- if config.hpa.avg_memory|length %}
   - type: Resource
     resource:
       name: memory
       target:
         type: AverageValue
-        averageValue: {{ POD_AUTOSCALING_LMS_WORKER_AVG_MEMORY }}
+        averageValue: {{ config.hpa.avg_memory }}
   {%- endif %}
 {%- endif %}
-{%- if POD_AUTOSCALING_CMS_HPA %}
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: cms-hpa
-  labels:
-    app.kubernetes.io/name: cms-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: cms
-  minReplicas: {{ POD_AUTOSCALING_CMS_MIN_REPLICAS }}
-  maxReplicas: {{ POD_AUTOSCALING_CMS_MAX_REPLICAS }}
-  metrics:
-  {%- if POD_AUTOSCALING_CMS_AVG_CPU > 0 %}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ POD_AUTOSCALING_CMS_AVG_CPU }}
-  {%- endif %}
-  {%- if POD_AUTOSCALING_CMS_AVG_MEMORY|length %}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: AverageValue
-        averageValue: {{ POD_AUTOSCALING_CMS_AVG_MEMORY }}
-  {%- endif %}
-{%- endif %}
-{%- if POD_AUTOSCALING_CMS_WORKER_HPA %}
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: cms-worker-hpa
-  labels:
-    app.kubernetes.io/name: cms-worker-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: cms-worker
-  minReplicas: {{ POD_AUTOSCALING_CMS_WORKER_MIN_REPLICAS }}
-  maxReplicas: {{ POD_AUTOSCALING_CMS_WORKER_MAX_REPLICAS }}
-  metrics:
-  {%- if POD_AUTOSCALING_CMS_WORKER_AVG_CPU > 0 %}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ POD_AUTOSCALING_CMS_WORKER_AVG_CPU }}
-  {%- endif %}
-  {%- if POD_AUTOSCALING_CMS_WORKER_AVG_MEMORY|length %}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: AverageValue
-        averageValue: {{ POD_AUTOSCALING_CMS_WORKER_AVG_MEMORY }}
-  {%- endif %}
-{%- endif %}
+{% endfor %}
+
 {{ patch("pod-autoscaling-hpa") }}

--- a/tutorpod_autoscaling/templates/pod-autoscaling/k8s/vpa.yml
+++ b/tutorpod_autoscaling/templates/pod-autoscaling/k8s/vpa.yml
@@ -1,56 +1,18 @@
-{%- if POD_AUTOSCALING_LMS_VPA %}
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: vpa-recommender-lms
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind:       Deployment
-    name:       lms
-  updatePolicy:
-    updateMode: "Off"
-{%- endif %}
-{%- if POD_AUTOSCALING_LMS_WORKER_VPA %}
+{% for service_name, config in POD_AUTOSCALING_SERVICES.items() %}
+{%- if config.vpa.enabled %}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: vpa-recommender-lms-worker
+  name: vpa-recommender-{{ service_name }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind:       Deployment
-    name:       lms-worker
+    name:       {{ service_name }}
   updatePolicy:
     updateMode: "Off"
-{%- endif %}
-{%- if POD_AUTOSCALING_CMS_VPA %}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: vpa-recommender-cms
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind:       Deployment
-    name:       cms
-  updatePolicy:
-    updateMode: "Off"
-{%- endif %}
-{%- if POD_AUTOSCALING_CMS_WORKER_VPA %}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: vpa-recommender-cms-worker
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind:       Deployment
-    name:       cms-worker
-  updatePolicy:
-    updateMode: "Off"
-{%- endif %}
+{% endif %}
+{% endfor %}
+
 {{ patch("pod-autoscaling-vpa") }}


### PR DESCRIPTION
## Description

This PR allows configuring HPA and VPA for multiple services. It's a backward-compatible change as the old variables are used as defaults for the CMS, LMS, LMS-WORKER, and CMS-WORKER.

### Author concern:
- After comparing the main branch vs. this PR, I only see one difference in the generated configuration. This is because the CMS was using the configuration for the CMS-WORKER.

```diff
 apiVersion: apps/v1
 kind: Deployment
@@ -44,11 +47,12 @@ spec:
         - name: cms
           resources:
             requests:
-              memory: 750Mi
-              cpu: 0.175
+              memory: 350Mi
+              cpu: 0.25
             limits:
-              memory: 3000Mi
+              memory: 1400Mi
               cpu: 1
+
```

Is this intended?