### PR TITLE
fix: remove pkg_resources for compatibility with python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ master, main, nightly ]
+  pull_request:
+    branches: [ master, main, nightly ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+         python-version: ['3.8', '3.12']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
+      - name: Test lint, types, and format
+        run: make test

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ setup(
     include_package_data=True,
     python_requires=">=3.8",
     install_requires=["tutor>=17.0.0,<18.0.0"],
+    extras_require={
+        "dev": [
+            "tutor[dev]>=17.0.0,<18.0.0",
+        ]
+    },
     entry_points={
         "tutor.plugin.v1": [
             "pod-autoscaling = tutorpod_autoscaling.plugin"

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -7,6 +7,8 @@ from glob import glob
 import importlib_resources
 from tutor import hooks
 
+from typing import Dict, Union
+
 from .__about__ import __version__
 
 ################# Autoscaling
@@ -25,7 +27,7 @@ LMS_MEMORY_REQUEST_MB = 350
 LMS_MAX_REPLICAS = 4
 LMS_WORKER_MEMORY_REQUEST_MB = 750
 
-config = {
+config: Dict[str, Dict[str, Union[bool, str, float]]] = {
     "defaults": {
         "VERSION": __version__,
         "CMS_MEMORY_REQUEST": f"{CMS_MEMORY_REQUEST_MB}Mi",
@@ -77,14 +79,18 @@ config = {
 
 # Add configuration entries
 hooks.Filters.CONFIG_DEFAULTS.add_items(
-    [(f"POD_AUTOSCALING_{key}", value) for key, value in config.get("defaults", {}).items()]
+    [
+        (f"POD_AUTOSCALING_{key}", value)
+        for key, value in config.get("defaults", {}).items()
+    ]
 )
 hooks.Filters.CONFIG_UNIQUE.add_items(
-    [(f"POD_AUTOSCALING_{key}", value) for key, value in config.get("unique", {}).items()]
+    [
+        (f"POD_AUTOSCALING_{key}", value)
+        for key, value in config.get("unique", {}).items()
+    ]
 )
-hooks.Filters.CONFIG_OVERRIDES.add_items(
-    list(config.get("overrides", {}).items())
-)
+hooks.Filters.CONFIG_OVERRIDES.add_items(list(config.get("overrides", {}).items()))
 
 
 # Add the "templates" folder as a template root
@@ -101,6 +107,8 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 )
 
 # Load patches from files
-for path in glob(str(importlib_resources.files("tutorpod_autoscaling") / "patches" / "*")):
+for path in glob(
+    str(importlib_resources.files("tutorpod_autoscaling") / "patches" / "*")
+):
     with open(path, encoding="utf-8") as patch_file:
         hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -77,12 +77,14 @@ config = {
 
 # Add configuration entries
 hooks.Filters.CONFIG_DEFAULTS.add_items(
-    [(f"POD_AUTOSCALING_{key}", value) for key, value in config["defaults"].items()]
+    [(f"POD_AUTOSCALING_{key}", value) for key, value in config.get("defaults", {}).items()]
 )
 hooks.Filters.CONFIG_UNIQUE.add_items(
-    [(f"POD_AUTOSCALING_{key}", value) for key, value in config["unique"].items()]
+    [(f"POD_AUTOSCALING_{key}", value) for key, value in config.get("unique", {}).items()]
 )
-hooks.Filters.CONFIG_OVERRIDES.add_items(list(config["overrides"].items()))
+hooks.Filters.CONFIG_OVERRIDES.add_items(
+    list(config.get("overrides", {}).items())
+)
 
 
 # Add the "templates" folder as a template root

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -4,8 +4,7 @@ import os
 import os.path
 from glob import glob
 
-import click
-import pkg_resources
+import importlib_resources
 from tutor import hooks
 
 from .__about__ import __version__
@@ -88,7 +87,7 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(list(config["overrides"].items()))
 
 # Add the "templates" folder as a template root
 hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(
-    pkg_resources.resource_filename("tutorpod_autoscaling", "templates"),
+    str(importlib_resources.files("tutorpod_autoscaling") / "templates")
 )
 # Render the "build" and "apps" folders
 hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
@@ -100,11 +99,6 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 )
 
 # Load patches from files
-for path in glob(
-    os.path.join(
-        pkg_resources.resource_filename("tutorpod_autoscaling", "patches"),
-        "*",
-    )
-):
+for path in glob(str(importlib_resources.files("tutorpod_autoscaling") / "patches" / "*")):
     with open(path, encoding="utf-8") as patch_file:
         hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))


### PR DESCRIPTION
### Description

This PR removes the `pkg_resources` dependency in favor of `importlib_resources`.