### PR TITLE
fix: remove cms_worker values in cms deployment

### DIFF
--- a/tutorpod_autoscaling/patches/k8s-override
+++ b/tutorpod_autoscaling/patches/k8s-override
@@ -57,14 +57,14 @@ spec:
         - name: cms
           resources:
             requests:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_REQUEST }}
-            {%- if POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_REQUEST }}
+              memory: {{ POD_AUTOSCALING_CMS_MEMORY_REQUEST }}
+            {%- if POD_AUTOSCALING_CMS_CPU_REQUEST > 0 %}
+              cpu: {{ POD_AUTOSCALING_CMS_CPU_REQUEST }}
             {%- endif %}
             limits:
-              memory: {{ POD_AUTOSCALING_CMS_WORKER_MEMORY_LIMIT }}
-              {%- if POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT > 0 %}
-              cpu: {{ POD_AUTOSCALING_CMS_WORKER_CPU_LIMIT }}
+              memory: {{ POD_AUTOSCALING_CMS_MEMORY_LIMIT }}
+              {%- if POD_AUTOSCALING_CMS_CPU_LIMIT > 0 %}
+              cpu: {{ POD_AUTOSCALING_CMS_CPU_LIMIT }}
               {%- endif %}
 {%- endif %}
 {%- if POD_AUTOSCALING_CMS_WORKER_HPA %}


### PR DESCRIPTION
# Description

I have to fork, anyway, we were facing this behavior changing cms_worker values.

![image](https://github.com/eduNEXT/tutor-contrib-pod-autoscaling/assets/51926076/29ca9f01-198d-44b3-b29a-3e1acba3991f)