### PR TITLE
fix: allow to disable/enable resource limits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,8 @@ You can also override the HPA/VPA configuration for any of the services supporte
     - Using only one of the 2 mechanisms available is strongly recommended to prevent potential misconfiguration.
     - VPA components can be enabled/disabled for different deployments thanks to the ``enable_vpa`` key defined on every configured service. The VPAs are configured with the **UpdateMode** mode disabled, so they don't modify Pod resources automatically. Instead, they work as a dry-run, setting the recommended resources for the deployments in every VPA object.
 
+3. In case you want to disable resource limits you can use the following setting: `POD_AUTOSCALING_ENABLE_RESOURCE_MANAGEMENT: false`
+
 Migrating to Redwood version (18.x.x)
 -------------------------------------
 

--- a/tutorpod_autoscaling/patches/k8s-override
+++ b/tutorpod_autoscaling/patches/k8s-override
@@ -1,5 +1,6 @@
+{% if POD_AUTOSCALING_ENABLE_RESOURCE_MANAGEMENT %}
 {% set autoscaling_config = dict(iter_autoscaling_config().items(), **POD_AUTOSCALING_EXTRA_SERVICES) %}
-{% for service, autoscaling in autoscaling_config.items() if autoscaling.get("enable_hpa") %}
+{% for service, autoscaling in autoscaling_config.items() %}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -22,3 +23,4 @@ spec:
               cpu: {{ autoscaling["cpu_limit"] }}
               {%- endif %}
 {% endfor %}
+{% endif %}

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -32,7 +32,11 @@ LMS_WORKER_MEMORY_REQUEST_MB = 750
 config: Dict[
     str, Dict[str, Union[bool, str, float, dict[str, AUTOSCALING_ATTRS_TYPE]]]
 ] = {
-    "defaults": {"VERSION": __version__, "EXTRA_SERVICES": {}},
+    "defaults": {
+        "VERSION": __version__,
+        "EXTRA_SERVICES": {},
+        "ENABLE_RESOURCE_MANAGEMENT": True,
+    },
     "unique": {},
     "overrides": {},
 }


### PR DESCRIPTION
### Description

This PR allows to disable/enable resource limits via a setting: `POD_AUTOSCALING_ENABLE_RESOURCE_MANAGEMENT`