### PR TITLE
build: add the build package to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "python-semantic-release",
   "black",
+  "build",
+  "isort",
   "mypy",
   "pylint",
-  "isort",
+  "python-semantic-release",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is used to build the wheel needed to publish to PyPI.