### PR TITLE
feat: add optional behavior block to HPA template

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ def _add_my_autoscaling(autoscaling_config):
         "avg_cpu": 300,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     }
     return autoscaling_config
 ```
@@ -97,6 +98,7 @@ def _add_my_autoscaling(autoscaling_config):
         "avg_cpu": 70,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     }
     return autoscaling_config
 ```
@@ -117,6 +119,7 @@ POD_AUTOSCALING_EXTRA_SERVICES:
         avg_cpu: 300
         avg_memory: ''
         enable_vpa: true
+        behavior: {}
     lms:
         enable_hpa: true
         memory_request: 1Gi
@@ -128,6 +131,7 @@ POD_AUTOSCALING_EXTRA_SERVICES:
         avg_cpu: 70
         avg_memory: ''
         enable_vpa: true
+        behavior: {}
 ```
 
 > [!NOTE]
@@ -146,6 +150,23 @@ POD_AUTOSCALING_EXTRA_SERVICES:
 >   with the **UpdateMode** mode disabled, so they don't modify Pod resources
 >   automatically. Instead, they work as a dry-run, setting the recommended
 >   resources for the deployments in every VPA object.
+
+### Configuring HPA scaling behaviour
+
+> [!NOTE]
+> The `behavior` field is available from version 22.1.0 (Verawood) onward.
+
+Set `behavior` to control HPA scale-up and scale-down dynamics. An empty dict (`{}`) omits the block, preserving Kubernetes defaults. See the [Kubernetes HPA behaviour docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configuring-hpa-behavior) for all supported fields.
+
+``` yaml
+behavior:
+  scaleDown:
+    stabilizationWindowSeconds: 900
+    policies:
+    - type: Percent
+      value: 10
+      periodSeconds: 120
+```
 
 ## Migrating to Redwood version (18.x.x)
 
@@ -187,6 +208,7 @@ def _add_my_autoscaling(autoscaling_config):
         "avg_cpu": 300,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     }
     return autoscaling_config
 ```

--- a/tutorpod_autoscaling/hooks.py
+++ b/tutorpod_autoscaling/hooks.py
@@ -11,6 +11,23 @@ from typing import TypedDict
 from tutor.core.hooks import Filter
 
 
+class HPAScalingPolicyType(TypedDict):
+    type: str
+    value: int
+    periodSeconds: int
+
+
+class HPAScalingRulesType(TypedDict, total=False):
+    stabilizationWindowSeconds: int
+    selectPolicy: str  # Max | Min | Disabled
+    policies: list[HPAScalingPolicyType]
+
+
+class HPABehaviorType(TypedDict, total=False):
+    scaleDown: HPAScalingRulesType
+    scaleUp: HPAScalingRulesType
+
+
 class AUTOSCALING_ATTRS_TYPE(TypedDict):
     enable_hpa: bool
     memory_limit: str
@@ -22,6 +39,7 @@ class AUTOSCALING_ATTRS_TYPE(TypedDict):
     avg_cpu: int
     avg_memory: str
     enable_vpa: bool
+    behavior: HPABehaviorType
 
 
 AUTOSCALING_CONFIG: Filter[dict[str, AUTOSCALING_ATTRS_TYPE], []] = Filter()

--- a/tutorpod_autoscaling/plugin.py
+++ b/tutorpod_autoscaling/plugin.py
@@ -44,6 +44,7 @@ CORE_AUTOSCALING_CONFIG: dict[str, AUTOSCALING_ATTRS_TYPE] = {
         "avg_cpu": 100,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     },
     "lms-worker": {
         "enable_hpa": True,
@@ -56,6 +57,7 @@ CORE_AUTOSCALING_CONFIG: dict[str, AUTOSCALING_ATTRS_TYPE] = {
         "avg_cpu": 100,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     },
     "cms": {
         "enable_hpa": True,
@@ -68,6 +70,7 @@ CORE_AUTOSCALING_CONFIG: dict[str, AUTOSCALING_ATTRS_TYPE] = {
         "avg_cpu": 100,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     },
     "cms-worker": {
         "enable_hpa": True,
@@ -80,6 +83,7 @@ CORE_AUTOSCALING_CONFIG: dict[str, AUTOSCALING_ATTRS_TYPE] = {
         "avg_cpu": 100,
         "avg_memory": "",
         "enable_vpa": False,
+        "behavior": {},
     },
 }
 

--- a/tutorpod_autoscaling/templates/pod-autoscaling/k8s/hpa.yml
+++ b/tutorpod_autoscaling/templates/pod-autoscaling/k8s/hpa.yml
@@ -31,4 +31,44 @@ spec:
         type: AverageValue
         averageValue: {{ autoscaling["avg_memory"] }}
   {%- endif %}
+  {%- if autoscaling.get("behavior") %}
+  {%- set beh = autoscaling["behavior"] %}
+  behavior:
+  {%- if beh.get("scaleDown") %}
+  {%- set sd = beh["scaleDown"] %}
+    scaleDown:
+  {%- if sd.get("stabilizationWindowSeconds") is not none %}
+      stabilizationWindowSeconds: {{ sd["stabilizationWindowSeconds"] }}
+  {%- endif %}
+  {%- if sd.get("selectPolicy") %}
+      selectPolicy: {{ sd["selectPolicy"] }}
+  {%- endif %}
+  {%- if sd.get("policies") %}
+      policies:
+  {%- for p in sd["policies"] %}
+      - type: {{ p["type"] }}
+        value: {{ p["value"] }}
+        periodSeconds: {{ p["periodSeconds"] }}
+  {%- endfor %}
+  {%- endif %}
+  {%- endif %}
+  {%- if beh.get("scaleUp") %}
+  {%- set su = beh["scaleUp"] %}
+    scaleUp:
+  {%- if su.get("stabilizationWindowSeconds") is not none %}
+      stabilizationWindowSeconds: {{ su["stabilizationWindowSeconds"] }}
+  {%- endif %}
+  {%- if su.get("selectPolicy") %}
+      selectPolicy: {{ su["selectPolicy"] }}
+  {%- endif %}
+  {%- if su.get("policies") %}
+      policies:
+  {%- for p in su["policies"] %}
+      - type: {{ p["type"] }}
+        value: {{ p["value"] }}
+        periodSeconds: {{ p["periodSeconds"] }}
+  {%- endfor %}
+  {%- endif %}
+  {%- endif %}
+  {%- endif %}
 {% endfor %}


### PR DESCRIPTION
## What

Adds optional `behavior` support to the HPA template, allowing operators to configure scale-up and scale-down dynamics per service.

## Why

Without a `behavior` block, Kubernetes applies its defaults: no scale-up stabilisation and a 5-minute scale-down window. For workloads with wave-like traffic patterns — common in educational platforms with school-hour peaks — the default scale-down window causes the HPA to shed replicas too aggressively between waves, leaving the fleet under-provisioned when the next spike arrives.

This change makes the full [Kubernetes HPA behavior API](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configuring-hpa-behavior) available through the existing `AUTOSCALING_CONFIG` filter and `POD_AUTOSCALING_EXTRA_SERVICES` config, with no impact on operators who don't set it.

## Changes

- `AUTOSCALING_ATTRS_TYPE` gains a typed `behavior` field (`HPABehaviorType`) with typed sub-dicts for `scaleDown` and `scaleUp`, each supporting `stabilizationWindowSeconds`, `selectPolicy`, and a `policies` list.
- The `hpa.yml` template renders the `behavior` block only when the field is non-empty, so all existing configs continue to work unchanged.

## Usage

See [updated README](https://github.com/Euka-Future-Learning/tutor-contrib-pod-autoscaling/blob/feat/hpa-behavior-block/README.md#configuring-hpa-scaling-behaviour) for usage example.

## Backward compatibility

Fully backward compatible. Services with `behavior: {}` (the default for all built-in services) produce no `behavior` block in the rendered HPA manifest, preserving existing Kubernetes defaults.